### PR TITLE
Minor Fixes

### DIFF
--- a/last_shout/main.py
+++ b/last_shout/main.py
@@ -189,8 +189,6 @@ def main():
     if opts.tweet:
         status = send_tweet(settings, twitter_text, None)
         print(f"Last.fm statistics posted to Twitter at {status.created_at}")
-    else:
-        print(twitter_text)
 
     if opts.toot:
         if not has_mastodon_app_credentials(
@@ -201,6 +199,9 @@ def main():
 
         status = sent_toot(settings, twitter_text)
         print(f"Last.fm statistics posted to Mastodon at {status.created_at}")
+
+    if not opts.tweet and not opts.toot:
+        print(twitter_text)
 
 
 if __name__ == "__main__":

--- a/last_shout/main.py
+++ b/last_shout/main.py
@@ -48,9 +48,9 @@ def has_mastodon_user_credentials(settings):
 
 
 def create_mastodon_app(settings):
+    app_name = "Last-Shout"
+    app_url = "https://github.com/bpepple/last-shout"
     instance = input("Enter Mastodon instance (ex. 'https://mastodon.social'): ")
-    app_name = input("Enter name of application (ex. LastShout): ")
-    app_url = input("End url of application: ")
 
     client_id, client_secret = Mastodon.create_app(
         app_name,
@@ -88,9 +88,7 @@ def create_mastodon_user_token(settings):
     auth = input("\nCopy the authorized code here to generate user token: ")
     try:
         user_token = mastodon.log_in(
-            code=auth,
-            scopes=["write"],
-            redirect_uri="urn:ietf:wg:oauth:2.0:oob",
+            code=auth, scopes=["write"], redirect_uri="urn:ietf:wg:oauth:2.0:oob",
         )
     except MastodonIllegalArgumentError:
         return False

--- a/last_shout/main.py
+++ b/last_shout/main.py
@@ -57,7 +57,6 @@ def create_mastodon_app(settings):
         website=app_url,
         api_base_url=instance,
         redirect_uris="urn:ietf:wg:oauth:2.0:oob",
-        to_file="pytooter_clientcred.txt",
     )
 
     if not (client_id or client_secret):
@@ -92,7 +91,6 @@ def create_mastodon_user_token(settings):
             code=auth,
             scopes=["write"],
             redirect_uri="urn:ietf:wg:oauth:2.0:oob",
-            to_file="pytooter_usercred.secret",
         )
     except MastodonIllegalArgumentError:
         return False


### PR DESCRIPTION
- Only print tweet text output if not sending to Twitter or Mastodon.
- Supply the Mastodon application information instead of asking user.  Makes more sense than asking the user to create some bogus information.